### PR TITLE
feat: auto-resolve blocking deps not in EPIC_IDS

### DIFF
--- a/go/internal/cli/commands_scripts.go
+++ b/go/internal/cli/commands_scripts.go
@@ -675,29 +675,28 @@ print('' if v is None else v)
 `
 }
 
-// loopScriptEpicSelector returns the check_deps_closed and get_next_epic bash functions.
+// loopScriptEpicSelector returns the check_deps_closed, get_blocking_dep, and get_next_epic bash functions.
 func loopScriptEpicSelector() string { //nolint:funlen // bash template string
 	return `# --- Epic Selector ---
 
-# check_deps_closed() - Verify all depends_on for an epic are closed
-# Returns 0 if all deps closed (or no deps), 1 if any dep is open
-check_deps_closed() {
+# get_blocking_dep() - Return the first open dependency ID for an epic
+# Prints the blocking dep ID to stdout, or empty if all deps closed.
+get_blocking_dep() {
   local epic_id="$1"
   local deps_json
   deps_json=$(bd show "$epic_id" --json 2>/dev/null || echo "")
   if [ -z "$deps_json" ]; then
-    return 0
+    return
   fi
-  local blocking_dep
   if [ "$HAS_JQ" = true ]; then
-    blocking_dep=$(echo "$deps_json" | jq -r '
+    echo "$deps_json" | jq -r '
       if type == "array" then .[0] else . end |
       (.depends_on // .dependencies // []) |
       map(select(.status != "closed")) |
       .[0].id // empty
-    ' 2>/dev/null || echo "")
+    ' 2>/dev/null || true
   else
-    blocking_dep=$(echo "$deps_json" | python3 -c "
+    echo "$deps_json" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 if isinstance(data, list):
@@ -708,8 +707,16 @@ for d in deps:
     if s != 'closed':
         print(d.get('id', d) if isinstance(d, dict) else d)
         break
-" 2>/dev/null || echo "")
+" 2>/dev/null || true
   fi
+}
+
+# check_deps_closed() - Verify all depends_on for an epic are closed
+# Returns 0 if all deps closed (or no deps), 1 if any dep is open
+check_deps_closed() {
+  local epic_id="$1"
+  local blocking_dep
+  blocking_dep=$(get_blocking_dep "$epic_id")
   if [ -n "$blocking_dep" ]; then
     log "Skip $epic_id: blocked by dependency $blocking_dep (not closed)"
     return 1
@@ -719,6 +726,7 @@ for d in deps:
 
 get_next_epic() {
   if [ -n "$EPIC_IDS" ]; then
+    # First pass: find an unblocked, open epic from the target list
     for epic_id in $EPIC_IDS; do
       case " $PROCESSED " in (*" $epic_id "*) continue ;; esac
       local status
@@ -729,6 +737,30 @@ get_next_epic() {
         return 0
       fi
     done
+
+    # Second pass: if all remaining epics are blocked, try to resolve blockers.
+    # This handles beads injected at runtime (e.g. by an external system) that
+    # are not in EPIC_IDS but block an epic that is.
+    for epic_id in $EPIC_IDS; do
+      case " $PROCESSED " in (*" $epic_id "*) continue ;; esac
+      local status
+      status=$(bd show "$epic_id" --json 2>/dev/null | parse_json '.status' 2>/dev/null || echo "")
+      if [ "$status" = "open" ]; then
+        local blocker
+        blocker=$(get_blocking_dep "$epic_id")
+        if [ -n "$blocker" ]; then
+          case " $PROCESSED " in (*" $blocker "*) continue ;; esac
+          local blocker_status
+          blocker_status=$(bd show "$blocker" --json 2>/dev/null | parse_json '.status' 2>/dev/null || echo "")
+          if [ "$blocker_status" = "open" ]; then
+            log "Resolving blocker $blocker for $epic_id"
+            echo "$blocker"
+            return 0
+          fi
+        fi
+      fi
+    done
+
     return 1
   else
     local epic_id

--- a/go/internal/cli/commands_scripts.go
+++ b/go/internal/cli/commands_scripts.go
@@ -345,20 +345,9 @@ func runLoop(cmd *cobra.Command, o *loopCmdOptions) error {
 		}
 	}
 
-	opts := loopGenerateOptions{maxRetries: o.maxRetries, model: o.model, epics: o.epics, compactPct: o.compactPct}
-
-	if o.reviewers != "" {
-		reviewerList := strings.Split(o.reviewers, ",")
-		if err := validateReviewers(reviewerList); err != nil {
-			return err
-		}
-		opts.review = &loopReviewOptions{
-			reviewers: reviewerList, maxReviewCycles: o.maxReviewCycles,
-			reviewBlocking: o.reviewBlocking, reviewModel: o.reviewModel, reviewEvery: o.reviewEvery,
-		}
-	}
-	if o.improve {
-		opts.improve = &loopImproveOptions{maxIters: o.improveMaxIters, timeBudget: o.improveTimeBudget}
+	opts, err := buildLoopOptions(o)
+	if err != nil {
+		return err
 	}
 
 	script := generateLoopScript(opts)
@@ -372,6 +361,24 @@ func runLoop(cmd *cobra.Command, o *loopCmdOptions) error {
 	cmd.Printf("[ok] Generated infinity loop script: %s\n", output)
 	cmd.Println("Run it with: bash " + output)
 	return nil
+}
+
+func buildLoopOptions(o *loopCmdOptions) (loopGenerateOptions, error) {
+	opts := loopGenerateOptions{maxRetries: o.maxRetries, model: o.model, epics: o.epics, compactPct: o.compactPct}
+	if o.reviewers != "" {
+		reviewerList := strings.Split(o.reviewers, ",")
+		if err := validateReviewers(reviewerList); err != nil {
+			return opts, err
+		}
+		opts.review = &loopReviewOptions{
+			reviewers: reviewerList, maxReviewCycles: o.maxReviewCycles,
+			reviewBlocking: o.reviewBlocking, reviewModel: o.reviewModel, reviewEvery: o.reviewEvery,
+		}
+	}
+	if o.improve {
+		opts.improve = &loopImproveOptions{maxIters: o.improveMaxIters, timeBudget: o.improveTimeBudget}
+	}
+	return opts, nil
 }
 
 // loopGenerateOptions holds all options for generating the loop script.

--- a/go/internal/contracts/windows_integration_test.go
+++ b/go/internal/contracts/windows_integration_test.go
@@ -256,4 +256,3 @@ func TestContract_DSNPragmasApplied(t *testing.T) {
 		t.Errorf("busy_timeout = %d, want 5000", timeout)
 	}
 }
-

--- a/go/internal/hook/phase_state.go
+++ b/go/internal/hook/phase_state.go
@@ -36,13 +36,13 @@ var phaseIndexMap = map[string]int{
 
 // maxPhaseIndex returns the highest phase index in the map.
 func maxPhaseIndex() int {
-	max := 0
+	highest := 0
 	for _, idx := range phaseIndexMap {
-		if idx > max {
-			max = idx
+		if idx > highest {
+			highest = idx
 		}
 	}
-	return max
+	return highest
 }
 
 // PhaseStatePath returns the filesystem path for the phase state file.

--- a/go/internal/hook/phase_state_test.go
+++ b/go/internal/hook/phase_state_test.go
@@ -346,9 +346,9 @@ func TestGetPhaseState_ArchitectPhase(t *testing.T) {
 
 func TestMaxPhaseIndex(t *testing.T) {
 	t.Parallel()
-	max := maxPhaseIndex()
-	if max < 6 {
-		t.Errorf("maxPhaseIndex() = %d, want >= 6 (must include architect)", max)
+	highest := maxPhaseIndex()
+	if highest < 6 {
+		t.Errorf("maxPhaseIndex() = %d, want >= 6 (must include architect)", highest)
 	}
 }
 

--- a/go/internal/storage/knowledge_db.go
+++ b/go/internal/storage/knowledge_db.go
@@ -497,6 +497,7 @@ func (k *KnowledgeDB) HydrateChunks(ids []string) []KnowledgeChunk {
 		args[i] = id
 	}
 
+	//nolint:gosec // G202: b.String() contains only '?' and ',' — no user input is concatenated.
 	rows, err := k.db.Query(
 		"SELECT id, file_path, start_line, end_line, content_hash, text, model, updated_at FROM chunks WHERE id IN ("+b.String()+")",
 		args...,


### PR DESCRIPTION
## Summary
- When all remaining epics in `EPIC_IDS` are blocked, the loop now resolves the blocker automatically
- Extracts `get_blocking_dep()` as a reusable function from `check_deps_closed()`
- Adds a second pass in `get_next_epic()` that finds and processes open blockers
- Enables runtime bead injection by external orchestrators (e.g. mastermind)

## Use case
An external system (like [claudio-mastermind](https://github.com/Quanthome/claudio-mastermind)) creates a new bead mid-loop and wires it as a dependency of the PR description bead. The loop discovers the blocker and processes it before retrying the blocked epic.

## Test plan
- [x] All existing tests pass (`go test ./internal/cli/ -run TestLoop`)
- [x] Full test suite passes (only pre-existing telemetry test failure)
- [ ] Manual: generate script, inject a bead with `bd create` + `bd dep add` while loop runs, verify loop picks it up

Closes #12