### PR TITLE
fix(polish): respect POLISH_DRY_RUN in post-loop commit/push

### DIFF
--- a/go/internal/cli/commands_scripts_polish.go
+++ b/go/internal/cli/commands_scripts_polish.go
@@ -759,12 +759,13 @@ done
 func polishScriptPostLoop() string {
 	return `# --- Post Loop ---
 log "Polish loop completed: $CYCLES cycles"
-echo "{\"status\":\"completed\",\"cycles\":$CYCLES,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$LOG_DIR/.polish-status.json"
 
-# Commit and push results
+# Write status and commit/push results
 if [ "${POLISH_DRY_RUN:-}" = "1" ]; then
+  echo "{\"status\":\"dry-run-completed\",\"cycles\":$CYCLES,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$LOG_DIR/.polish-status.json"
   log "DRY RUN: would commit and push polish loop artifacts"
 else
+  echo "{\"status\":\"completed\",\"cycles\":$CYCLES,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$LOG_DIR/.polish-status.json"
   if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     log "Committing polish loop artifacts"
     git add docs/specs/polish-report-cycle-*.md .compound-agent/agent_logs/.polish-status.json 2>/dev/null || true

--- a/go/internal/cli/commands_scripts_polish.go
+++ b/go/internal/cli/commands_scripts_polish.go
@@ -762,14 +762,18 @@ log "Polish loop completed: $CYCLES cycles"
 echo "{\"status\":\"completed\",\"cycles\":$CYCLES,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$LOG_DIR/.polish-status.json"
 
 # Commit and push results
-if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-  log "Committing polish loop artifacts"
-  git add docs/specs/polish-report-cycle-*.md .compound-agent/agent_logs/.polish-status.json 2>/dev/null || true
-  git commit -m "chore: polish loop cycle completion" 2>/dev/null || true
-fi
-if git remote get-url origin >/dev/null 2>&1; then
-  log "Pushing results"
-  git push 2>/dev/null || log "WARN: git push failed (non-fatal)"
+if [ "${POLISH_DRY_RUN:-}" = "1" ]; then
+  log "DRY RUN: would commit and push polish loop artifacts"
+else
+  if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    log "Committing polish loop artifacts"
+    git add docs/specs/polish-report-cycle-*.md .compound-agent/agent_logs/.polish-status.json 2>/dev/null || true
+    git commit -m "chore: polish loop cycle completion" 2>/dev/null || true
+  fi
+  if git remote get-url origin >/dev/null 2>&1; then
+    log "Pushing results"
+    git push 2>/dev/null || log "WARN: git push failed (non-fatal)"
+  fi
 fi
 
 log "Done"

--- a/go/internal/cli/commands_scripts_polish_test.go
+++ b/go/internal/cli/commands_scripts_polish_test.go
@@ -820,3 +820,66 @@ func TestPolishCommand_CompactPctForwardedToInnerLoop(t *testing.T) {
 		t.Error("expected --compact-pct forwarded to inner ca loop call")
 	}
 }
+
+// TestPolishCommand_PostLoopRespectsDryRun pins the post-loop dry-run guard so
+// future refactors of polishScriptPostLoop cannot silently regress: the
+// .polish-status.json write, the git commit, and the git push must all sit
+// inside the POLISH_DRY_RUN=1 else branch, and a dry-run must emit a distinct
+// "dry-run-completed" status so monitoring tools can tell preflights apart
+// from real runs. Regression test for #16.
+func TestPolishCommand_PostLoopRespectsDryRun(t *testing.T) {
+	t.Parallel()
+	root := &cobra.Command{Use: "ca"}
+	root.AddCommand(polishCmd())
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "polish.sh")
+
+	_, err := executeCommand(root, "polish", "-o", outPath,
+		"--spec-file", "docs/SPEC.md", "--meta-epic", "ME1")
+	if err != nil {
+		t.Fatalf("polish command failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(outPath)
+	script := string(data)
+
+	postIdx := strings.Index(script, "# --- Post Loop ---")
+	if postIdx < 0 {
+		t.Fatal("missing '# --- Post Loop ---' section marker")
+	}
+	postLoop := script[postIdx:]
+
+	if !strings.Contains(postLoop, `[ "${POLISH_DRY_RUN:-}" = "1" ]`) {
+		t.Error("post-loop section missing POLISH_DRY_RUN guard")
+	}
+	if !strings.Contains(postLoop, "DRY RUN: would commit and push polish loop artifacts") {
+		t.Error("post-loop section missing dry-run log message")
+	}
+	if !strings.Contains(postLoop, `\"status\":\"dry-run-completed\"`) {
+		t.Error("dry-run path must write status=dry-run-completed (distinct from real-run completion)")
+	}
+
+	// Every git-mutating line and the real-run status write must appear AFTER
+	// the dry-run guard's `else` keyword so they cannot execute in dry-run.
+	elseIdx := strings.Index(postLoop, "\nelse\n")
+	if elseIdx < 0 {
+		t.Fatal("post-loop dry-run guard missing else branch")
+	}
+	mustBeGuarded := []string{
+		`\"status\":\"completed\"`,
+		"git commit -m",
+		"git push",
+		"git add docs/specs/polish-report-cycle",
+	}
+	for _, needle := range mustBeGuarded {
+		idx := strings.Index(postLoop, needle)
+		if idx < 0 {
+			t.Errorf("post-loop section missing expected line: %q", needle)
+			continue
+		}
+		if idx < elseIdx {
+			t.Errorf("line %q appears before the dry-run else branch — it would still execute in dry-run", needle)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Guards the final `git commit` / `git push` block in the generated `polish-loop.sh` with the same `POLISH_DRY_RUN` check used elsewhere in the script.
- Without this, `POLISH_DRY_RUN=1 bash polish-loop.sh` still creates a real commit on the current branch and pushes it to `origin`, defeating the purpose of a dry-run preflight.

Fixes #16

## Test plan
- [x] `go build ./...` succeeds
- [ ] Regenerate polish script via `ca polish ...` and confirm `POLISH_DRY_RUN=1 bash .compound-agent/polish-loop.sh` prints `DRY RUN: would commit and push polish loop artifacts` and leaves `git log` / working tree untouched
- [ ] Confirm a non-dry run still commits and pushes as before