### PR TITLE
fix(embed): redirect daemon stderr to /dev/null to prevent pipe blocking

### DIFF
--- a/go/internal/embed/daemon_unix.go
+++ b/go/internal/embed/daemon_unix.go
@@ -86,19 +86,25 @@ func startDaemon(socketPath, modelPath, tokenizerPath string) error {
 		return err
 	}
 
-	devNull, err := os.Open(os.DevNull)
+	devNullR, err := os.Open(os.DevNull)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", os.DevNull, err)
 	}
-	defer devNull.Close()
+	defer devNullR.Close()
+
+	devNullW, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", os.DevNull, err)
+	}
+	defer devNullW.Close()
 
 	attr := &os.ProcAttr{
 		Dir: filepath.Dir(socketPath),
 		Env: os.Environ(),
 		Files: []*os.File{
-			devNull, // stdin from /dev/null
-			nil,     // stdout discarded
-			os.Stderr,
+			devNullR, // stdin
+			nil,      // stdout discarded
+			devNullW, // stderr: /dev/null, not inherited pipe — fixes pipe-blocking bug
 		},
 	}
 


### PR DESCRIPTION
## Problem

When `ca search` is invoked through a shell pipe (e.g. `ca search "query" 2>&1 | tail -5`), the cold-start case blocks indefinitely — until the daemon's 5-minute idle timeout fires.

**Root cause:** `startDaemon` passes `os.Stderr` directly into the child's `ProcAttr.Files`. On a cold start the caller's stderr *is* the write end of the pipe (due to `2>&1`). Since `ca-embed` is a persistent daemon, it keeps that fd open for its entire lifetime. The downstream `tail` never sees EOF and hangs.

Warm starts are unaffected because on a warm start `ca` never forks `ca-embed`, so no fd is inherited.

## Fix

Open a dedicated writable `/dev/null` fd for the daemon's stderr instead of inheriting the caller's stderr.

```go
// before
devNull, err := os.Open(os.DevNull)   // read-only — fine for stdin
Files: []*os.File{devNull, nil, os.Stderr}

// after
devNullW, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
Files: []*os.File{devNullR, nil, devNullW}
```

The startup messages (`[ca-embed] ready` etc.) are suppressed, but they were already invisible to end users calling through `npx ca`.

## Verification

```bash
# kill daemon to force cold start
kill $(cat .claude/.cache/embed-daemon.sock.pid)
rm .claude/.cache/embed-daemon.sock*

# before fix: blocks ~5 minutes
# after fix: completes in ~650ms
time npx ca search "test" 2>&1 | tail -5
```