### PR TITLE
fix(verify-gates): support beads (bd) 0.63.x output (fixes #36)

### DIFF
--- a/go/internal/cli/commands_verify_gates.go
+++ b/go/internal/cli/commands_verify_gates.go
@@ -57,11 +57,16 @@ func parseBdShowDeps(raw string) ([]bdDep, error) {
 
 	issue := issues[0]
 
-	// Try depends_on, then dependencies
+	// Try depends_on, then dependencies, then dependents.
+	// bd 0.63.x exposes an epic's child tasks (incl. the Review/Compound
+	// gate tasks created via --parent) under "dependents" with
+	// dependency_type "parent-child"; older schemas used depends_on/dependencies.
 	var depsRaw interface{}
 	if d, ok := issue["depends_on"]; ok {
 		depsRaw = d
 	} else if d, ok := issue["dependencies"]; ok {
+		depsRaw = d
+	} else if d, ok := issue["dependents"]; ok {
 		depsRaw = d
 	}
 
@@ -83,8 +88,10 @@ func parseBdShowDeps(raw string) ([]bdDep, error) {
 	return deps, nil
 }
 
-// depsTextPattern matches lines like: → ✓ task-1: Review: Code review ● closed
-var depsTextPattern = regexp.MustCompile(`^\s+→\s+(✓|○)\s+\S+:\s+(.+?)\s+●`)
+// depsTextPattern matches dependency/child lines in `bd show` plain output.
+// bd <0.63 used "→ ✓ task-1: Review: … ●"; bd 0.63.x uses "↳ ○ id: Review: … ●"
+// (different arrow glyph, and an extra status glyph like ◐). Accept both.
+var depsTextPattern = regexp.MustCompile(`^\s+(?:→|↳)\s+(✓|○|◐|●)\s+\S+:\s+(.+?)\s+●`)
 
 // parseBdShowDepsText parses the plain text output of `bd show <id>` into dependencies.
 func parseBdShowDepsText(output string) []bdDep {
@@ -94,7 +101,8 @@ func parseBdShowDepsText(output string) []bdDep {
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "DEPENDS ON" {
+		// bd <0.63 header was "DEPENDS ON"; bd 0.63.x lists child tasks under "CHILDREN".
+		if trimmed == "DEPENDS ON" || trimmed == "CHILDREN" {
 			inDeps = true
 			continue
 		}
@@ -196,8 +204,12 @@ func fetchDeps(epicID string) ([]bdDep, error) {
 		return nil, fmt.Errorf("bd CLI not found; install with: ca install-beads")
 	}
 
-	// Use "--" to prevent epicID from being interpreted as a flag
-	out, err := exec.Command("bd", "show", "--", epicID, "--json").Output()
+	// Use "--" to prevent epicID from being interpreted as a flag.
+	// NOTE: --json MUST come before "--": in bd 0.63.x, "--" terminates flag
+	// parsing, so "bd show -- <id> --json" treats --json as a positional id
+	// (bd errors "no issue found matching --json") and emits the human tree,
+	// which then fails JSON parsing.
+	out, err := exec.Command("bd", "show", "--json", "--", epicID).Output()
 	if err == nil {
 		deps, parseErr := parseBdShowDeps(string(out))
 		if parseErr == nil {

--- a/go/internal/cli/commands_verify_gates_test.go
+++ b/go/internal/cli/commands_verify_gates_test.go
@@ -66,6 +66,19 @@ func TestParseBdShowDeps(t *testing.T) {
 			},
 		},
 		{
+			// bd 0.63.x exposes an epic's child tasks (created via --parent)
+			// under "dependents" with dependency_type "parent-child".
+			name: "json with dependents array (bd 0.63.x parent-child)",
+			input: `[{"id":"epic-1","title":"Parent","dependents":[
+				{"id":"epic-1.1","title":"Review: Code review","status":"closed"},
+				{"id":"epic-1.2","title":"Compound: Synthesize patterns","status":"open"}
+			]}]`,
+			want: []bdDep{
+				{ID: "epic-1.1", Title: "Review: Code review", Status: "closed"},
+				{ID: "epic-1.2", Title: "Compound: Synthesize patterns", Status: "open"},
+			},
+		},
+		{
 			name:    "empty deps",
 			input:   `[{"id":"epic-1","title":"Parent"}]`,
 			want:    []bdDep{},
@@ -124,6 +137,20 @@ DEPENDS ON
   → ✓ task-1: Review: Code review ● closed
   → ○ task-2: Compound: Synthesize patterns ● open
 BLOCKED BY
+`,
+			want: []bdDep{
+				{Title: "Review: Code review", Status: "closed"},
+				{Title: "Compound: Synthesize patterns", Status: "open"},
+			},
+		},
+		{
+			// bd 0.63.x lists child tasks under a "CHILDREN" header using the
+			// "↳" glyph instead of the old "DEPENDS ON" / "→" layout.
+			name: "bd 0.63.x CHILDREN section with ↳ glyph",
+			input: `○ epic-1 [EPIC] · Parent epic
+CHILDREN
+  ↳ ✓ epic-1.1: Review: Code review ● P3
+  ↳ ○ epic-1.2: Compound: Synthesize patterns ● P3
 `,
 			want: []bdDep{
 				{Title: "Review: Code review", Status: "closed"},


### PR DESCRIPTION
Fixes #36.

`ca verify-gates` reported every Review/Compound gate task as **missing** against **beads (`bd`) 0.63.x**, even when the tasks existed and were closed — breaking the cook-it FINAL GATE on any current `bd`. Three incompatibilities in `go/internal/cli/commands_verify_gates.go`:

1. **`--json` after `--`** — `exec.Command("bd","show","--",epicID,"--json")`. In bd 0.63.x `--` ends flag parsing, so `--json` becomes a positional id (bd: `no issue found matching "--json"`) and bd emits the human tree; the JSON decoder then fails on the `○` glyph (`invalid character 'â'`). → move `--json` before `--`.
2. **wrong field** — `parseBdShowDeps` read `depends_on`/`dependencies`; bd 0.63.x exposes an epic's child tasks under **`dependents`** (`dependency_type: parent-child`). → also check `dependents`.
3. **stale plain-text format** — fallback regex/headers expected `→`/`DEPENDS ON`; bd 0.63.x uses `↳`/`CHILDREN`. → accept both.

All changes are additive (older bd output still parses). Adds regression tests for the `dependents` field and the `CHILDREN`/`↳` layout.

**Verification:** built `ca` with these changes against `bd` 0.63.3 — `verify-gates` now reports `[PASS]` for closed gate tasks, `exists but is not closed` for open ones, and `missing` only when truly absent, on both `--parent` children and real cook-it epics. `go test ./internal/cli/` passes.

> Note: branched off this fork's `main` (behind upstream) because the CI token here lacks `workflow` scope to push a branch crossing upstream's `.github/workflows` changes. The diff is just the two files above; happy to rebase onto current `main` if preferred.
